### PR TITLE
fix: `vite dev` does not set process.env.NODE_ENV to 'development'

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,7 @@ import preprocess from 'svelte-preprocess'
 import { readFileSync } from 'fs'
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
-const dev = process.env.NODE_ENV === 'development'
+const dev = process.env.NODE_ENV !== 'production'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
❌ `vite build`
✔️ `vite dev`